### PR TITLE
Updates module name in Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'lame' {
+declare module '@flat/lame' {
     import { WriteStream } from 'fs';
     import { DuplexOptions } from 'stream';
 


### PR DESCRIPTION
The module name was updated [2 years ago](https://github.com/FlatIO/node-lame/commit/4f04975f6421bfa94aa5822c2595338c6517c847) but the module name in the type definitions haven't been updated to match. 